### PR TITLE
feat: add mocked chat UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import ProductList from './components/ProductList.jsx';
 import Cart from './components/Cart.jsx';
+import Chat from './components/Chat.jsx';
 import './App.css';
 
 export default function App() {
@@ -9,10 +10,12 @@ export default function App() {
       <nav>
         <Link to="/">Home</Link>
         <Link to="/cart">Cart</Link>
+        <Link to="/chat">Chat</Link>
       </nav>
       <Routes>
         <Route path="/" element={<ProductList />} />
         <Route path="/cart" element={<Cart />} />
+        <Route path="/chat" element={<Chat />} />
       </Routes>
     </Router>
   );

--- a/src/components/Chat.css
+++ b/src/components/Chat.css
@@ -1,0 +1,56 @@
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 80vh;
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  border: 1px solid #ddd;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.message {
+  margin-bottom: 0.5rem;
+}
+
+.message.user {
+  text-align: right;
+}
+
+.message.bot {
+  text-align: left;
+}
+
+.message img {
+  max-width: 200px;
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.input-area {
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem;
+  border-top: 1px solid #ddd;
+  gap: 0.5rem;
+}
+
+.input-area input[type="text"] {
+  padding: 0.5rem;
+}
+
+.preview {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.preview img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+}

--- a/src/components/Chat.jsx
+++ b/src/components/Chat.jsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import './Chat.css';
+
+export default function Chat() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [files, setFiles] = useState([]);
+
+  const handleSend = () => {
+    if (!input.trim() && files.length === 0) return;
+
+    const newMessage = {
+      id: Date.now(),
+      sender: 'user',
+      text: input,
+      attachments: files,
+    };
+
+    setMessages(prev => [...prev, newMessage]);
+    setInput('');
+    setFiles([]);
+
+    // mocked response
+    setTimeout(() => {
+      setMessages(prev => [
+        ...prev,
+        {
+          id: Date.now(),
+          sender: 'bot',
+          text: 'This is a mocked response.',
+          attachments: [],
+        },
+      ]);
+    }, 500);
+  };
+
+  const handleFileChange = e => {
+    const selected = Array.from(e.target.files).map(file => ({
+      file,
+      preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
+    }));
+    setFiles(selected);
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="messages">
+        {messages.map(msg => (
+          <div key={msg.id} className={`message ${msg.sender}`}>
+            {msg.text && <p>{msg.text}</p>}
+            {msg.attachments.map((att, idx) => (
+              att.preview ? (
+                <img key={idx} src={att.preview} alt="attachment" />
+              ) : (
+                <a key={idx} href="#" download={att.file.name}>
+                  {att.file.name}
+                </a>
+              )
+            ))}
+          </div>
+        ))}
+      </div>
+      <div className="input-area">
+        {files.length > 0 && (
+          <div className="preview">
+            {files.map((f, idx) => (
+              f.preview ? (
+                <img key={idx} src={f.preview} alt="preview" />
+              ) : (
+                <span key={idx}>{f.file.name}</span>
+              )
+            ))}
+          </div>
+        )}
+        <input
+          type="text"
+          placeholder="Type a message..."
+          value={input}
+          onChange={e => setInput(e.target.value)}
+        />
+        <input type="file" multiple onChange={handleFileChange} />
+        <button onClick={handleSend}>Send</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Chat component with message sending, mock responses, and file/photo attachments
- style chat interface and expose a chat route in the app

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689659d7c1dc8325970cc19ed376363f